### PR TITLE
fixed email feature

### DIFF
--- a/src/components/Contact/ContactUs.jsx
+++ b/src/components/Contact/ContactUs.jsx
@@ -50,7 +50,12 @@ const ContactUs = () => {
                         />
                       </svg>
                     </div>
-                    <p>Support@eventaura.tech</p>
+                    {/* <!-- Updated email address to include a mailto link --> */}
+                    <p>
+                      <a href="mailto:support@eventaura.tech">
+                        Support@eventaura.tech
+                      </a>
+                    </p>
                   </li>
                   <li className="flex items-center gap-x-3">
                     <div className="flex-none text-gray-400">


### PR DESCRIPTION
This update enhances the contact page by making the support email address clickable. Users can now click on the email address to directly open their default email client with the recipient's address pre-filled.